### PR TITLE
Build latest kube-scheduler and test

### DIFF
--- a/install_storage.sh
+++ b/install_storage.sh
@@ -139,18 +139,17 @@ EOF
 }
 
 # Build kube-scheduler container image and load the image in KinD.
-build_kube_scheduler() {
+build_kube_scheduler_image() {
     pushd "$GOPATH/src/k8s.io/kubernetes"
-        KUBE_BUILD_PLATFORMS=linux/amd64 make kube-scheduler
         generate_kube_scheduler_dockerfile > "Dockerfile"
-        docker build -t k8s.io/kube-scheduler:test -f Dockerfile _output/bin/
+        docker build -t k8s.io/kube-scheduler:test -f Dockerfile _output/dockerized/bin/linux/amd64/
         kind load docker-image k8s.io/kube-scheduler:test
         rm Dockerfile
     popd
 }
 
 install() {
-    build_kube_scheduler
+    build_kube_scheduler_image
     generate_stos_cluster_config > "storageoscluster_cr.yaml"
     install_stos
     generate_driver_config > "test-driver.yaml"

--- a/install_storage.sh
+++ b/install_storage.sh
@@ -78,7 +78,7 @@ spec:
   secretRefNamespace: "default"
   namespace: "storageos"
   images:
-    hyperkubeContainer: gcr.io/google_containers/hyperkube:$K8S_VERSION
+    kubeSchedulerContainer: k8s.io/kube-scheduler:test
   csi:
     enable: true
 EOF
@@ -130,7 +130,27 @@ DriverInfo:
 EOF
 }
 
+generate_kube_scheduler_dockerfile() {
+    cat <<EOF
+FROM gcr.io/distroless/base-debian10
+COPY kube-scheduler /usr/local/bin/kube-scheduler
+CMD ["/bin/sh", "-c"]
+EOF
+}
+
+# Build kube-scheduler container image and load the image in KinD.
+build_kube_scheduler() {
+    pushd "$GOPATH/src/k8s.io/kubernetes"
+        KUBE_BUILD_PLATFORMS=linux/amd64 make kube-scheduler
+        generate_kube_scheduler_dockerfile > "Dockerfile"
+        docker build -t k8s.io/kube-scheduler:test -f Dockerfile _output/bin/
+        kind load docker-image k8s.io/kube-scheduler:test
+        rm Dockerfile
+    popd
+}
+
 install() {
+    build_kube_scheduler
     generate_stos_cluster_config > "storageoscluster_cr.yaml"
     install_stos
     generate_driver_config > "test-driver.yaml"


### PR DESCRIPTION
After replacing hyperkube with kube-scheduler, kube-scheduler container
image can be built from the k/k source and used for testing. This can
help detect any new permission requirement in the future.